### PR TITLE
Support SCSI disk and update SATA check

### DIFF
--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -149,15 +149,21 @@ if inpath smartctl >/dev/null 2>&1; then
                 TEMP=
                 # create temperature output as expected by checks/smart
                 # this is a hack, TODO: change checks/smart to support SCSI-disks
-                eval "$(smartctl -d scsi -i -A "$D" | while read -r a b c d _; do
+                eval "$(smartctl -d scsi -i -A "$D" | while read -r a b c d e f _; do
                     [ "$a" == Serial ] && echo SN="$c"
                     [ "$a" == Current ] && [ "$b" == Drive ] && [ "$c" == Temperature: ] && echo TEMP="$d"
+                    [ "$a" == Accumulated ] && [ "$b" == power ] && [ "$c" == on ] && echo ON_TIME="$f"
+                    [ "$a" == Accumulated ] && [ "$b" == start-stop ] && echo PWR_CYCLE="$d"
+                    [ "$a" == Elements ] && [ "$c" == grown ] && [ "$d" == defect ] && echo DEFECT="$f"
                 done)"
-                [ -n "$TEMP" ] && CMD="echo 194 Temperature_Celsius 0x0000 000 000 000 Old_age Always - $TEMP (0 0 0 0)"
+                [ -n "$TEMP" ] && CMD="echo -e 194 Temperature_Celsius 0x0000 000 000 000 Old_age Always - $TEMP (0 0 0 0)"
+                [ -n "$ON_TIME" ] && CMD=$CMD"\n9 Power_On_Hours 0x0000 000 000 000 Old_age Always - ${ON_TIME%%:*}"
+                [ -n "$PWR_CYCLE" ] && CMD=$CMD"\n12 Power_Cycle_Count 0x0000 000 000 000 Old_age Always - $PWR_CYCLE"
+                [ -n "$DEFECT" ] && CMD=$CMD"\n5 Reallocated_Sector_Ct 0x0000 000 000 000 Pre-fail Always - $DEFECT"
                 DNAME="${VEND}_${MODEL}_${SN}"
             fi
         else
-            CMD="smartctl -d ata -v 9,raw48 -A $D"
+            CMD="smartctl -d sat -v 9,raw48 -A $D"
         fi
 
         if [ "$VEND" == "NVME" ]; then


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

Sample output from SCSI disk
```
smartctl -d scsi -A /dev/sde
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.1.0-21-amd64] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
Current Drive Temperature:     33 C
Drive Trip Temperature:        60 C

Accumulated power on time, hours:minutes 13323:18
Manufactured in week 17 of year 2021
Specified cycle count over device lifetime:  50000
Accumulated start-stop cycles:  26
Specified load-unload count over device lifetime:  600000
Accumulated load-unload cycles:  29313
Elements in grown defect list: 0
```

Update script to get Power on time, Power cycle and Reallocated Sector count.
Also update check command to modern SATA drives fall back instead of old ATA device.



## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
Returns check result for SCSI disks and SATA disks.

+ What is the observed behavior?
<<<smart>>>
SEAGATE_XXX SEAGATE ST16000NM002G 194 Temperature_Celsius 0x0000 000 000 000 Old_age Always - 35 (0 0 0 0)
SEAGATE_XXX SEAGATE ST16000NM002G 9 Power_On_Hours 0x0000 000 000 000 Old_age Always - 13322
SEAGATE_XXX SEAGATE ST16000NM002G 12 Power_Cycle_Count 0x0000 000 000 000 Old_age Always - 26
SEAGATE_XXX SEAGATE ST16000NM002G 5 Reallocated_Sector_Ct 0x0000 000 000 000 Pre-fail Always - 0

+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
